### PR TITLE
Pass Through id to Inner Password Input to Allow Label Click

### DIFF
--- a/dist/js/components/FormPasswordInput/FormPasswordInput.js
+++ b/dist/js/components/FormPasswordInput/FormPasswordInput.js
@@ -71,9 +71,10 @@ var FormPasswordInput = (_temp2 = _class = function (_React$Component) {
           onChange = _props.onChange,
           onBlur = _props.onBlur,
           value = _props.value,
+          id = _props.id,
           name = _props.name,
           placeholder = _props.placeholder,
-          other = _objectWithoutProperties(_props, ['className', 'onChange', 'onBlur', 'value', 'name', 'placeholder']);
+          other = _objectWithoutProperties(_props, ['className', 'onChange', 'onBlur', 'value', 'id', 'name', 'placeholder']);
 
       var hidePassword = this.state.hidePassword;
 
@@ -86,6 +87,7 @@ var FormPasswordInput = (_temp2 = _class = function (_React$Component) {
           className: 'form-control',
           'data-test-id': 'password-input',
           name: name,
+          id: id,
           onBlur: onBlur,
           onChange: onChange,
           placeholder: placeholder,
@@ -118,6 +120,7 @@ var FormPasswordInput = (_temp2 = _class = function (_React$Component) {
   return FormPasswordInput;
 }(React.Component), _class.propTypes = {
   className: _propTypes2.default.string,
+  id: _propTypes2.default.string,
   name: _propTypes2.default.string,
   onBlur: _propTypes2.default.func.isRequired,
   onChange: _propTypes2.default.func.isRequired,

--- a/src/js/components/FormPasswordInput/FormPasswordInput.js
+++ b/src/js/components/FormPasswordInput/FormPasswordInput.js
@@ -5,6 +5,7 @@ import Button from '../Button/Button';
 
 type Props = {
   className?: string,
+  id?: string,
   name?: string,
   onBlur: (SyntheticKeyboardEvent<HTMLInputElement>) => void,
   onChange: (SyntheticKeyboardEvent<HTMLInputElement>) => void,
@@ -32,7 +33,7 @@ class FormPasswordInput extends React.Component<Props, State> {
   };
 
   render() {
-    const { className, onChange, onBlur, value, name, placeholder, ...other } = this.props;
+    const { className, onChange, onBlur, value, id, name, placeholder, ...other } = this.props;
     const { hidePassword } = this.state;
     const classes = classNames(className, 'form-password-input', 'input-group');
 
@@ -42,6 +43,7 @@ class FormPasswordInput extends React.Component<Props, State> {
           className="form-control"
           data-test-id="password-input"
           name={name}
+          id={id}
           onBlur={onBlur}
           onChange={onChange}
           placeholder={placeholder}

--- a/src/js/components/FormPasswordInput/FormPasswordInput.spec.js
+++ b/src/js/components/FormPasswordInput/FormPasswordInput.spec.js
@@ -35,10 +35,10 @@ describe('<FormPasswordInput />', () => {
   });
 
   it('should pass through other props', () => {
-    const { wrapper } = setup({ tabIndex: 1, id: 'test', className: 'custom' });
+    const { wrapper } = setup({ tabIndex: 1, 'data-test': 'test', className: 'custom' });
 
     expect(wrapper.prop('tabIndex')).toEqual(1);
-    expect(wrapper.prop('id')).toEqual('test');
+    expect(wrapper.prop('data-test')).toEqual('test');
   });
 
   it('defaults name parameter to password', () => {
@@ -91,6 +91,13 @@ describe('<FormPasswordInput />', () => {
       const { input } = setup({ name });
 
       expect(input.prop('name')).toEqual(name);
+    });
+
+    it('passes through id', () => {
+      const id = 'secretPassword';
+      const { input } = setup({ id });
+
+      expect(input.prop('id')).toEqual(id);
     });
   });
 


### PR DESCRIPTION
Passes through `id` to the inner password element to allow `for` in `label` elements to be clicked to focus the input.

## Types of changes

What types of changes does your code introduce to the project?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

Please use the following checklist before contributing to this repository.

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have implemented error checking and considered data not being available or loading
- [ ] I have added necessary documentation (if appropriate)
- [x] I have implemented correct type checking
- [x] I have tested my changes on a mobile layout
- [ ] I have double checked with the team that I haven't introduced duplicates in functionalities (components, services, database changes, etc...)
- [ ] If required, designers have signed off my changes
- [ ] I have communicated the changes to the QA team and planned testing
- [ ] I have implemented e2e tests for the new functionality
