### PR TITLE
Props to FormPasswordInput

### DIFF
--- a/dist/js/components/FormPasswordInput/FormPasswordInput.js
+++ b/dist/js/components/FormPasswordInput/FormPasswordInput.js
@@ -18,9 +18,7 @@ var _classnames = require('classnames');
 
 var _classnames2 = _interopRequireDefault(_classnames);
 
-var _Button = require('../Button/Button');
-
-var _Button2 = _interopRequireDefault(_Button);
+var _ = require('../../');
 
 var _propTypes = require('prop-types');
 
@@ -72,9 +70,12 @@ var FormPasswordInput = (_temp2 = _class = function (_React$Component) {
           onBlur = _props.onBlur,
           value = _props.value,
           id = _props.id,
+          isInvalid = _props.isInvalid,
+          isValid = _props.isValid,
           name = _props.name,
           placeholder = _props.placeholder,
-          other = _objectWithoutProperties(_props, ['className', 'onChange', 'onBlur', 'value', 'id', 'name', 'placeholder']);
+          size = _props.size,
+          other = _objectWithoutProperties(_props, ['className', 'onChange', 'onBlur', 'value', 'id', 'isInvalid', 'isValid', 'name', 'placeholder', 'size']);
 
       var hidePassword = this.state.hidePassword;
 
@@ -82,28 +83,32 @@ var FormPasswordInput = (_temp2 = _class = function (_React$Component) {
 
       return React.createElement(
         'div',
-        _extends({}, other, { className: 'form-password-input input-group' }),
-        React.createElement('input', {
+        { className: 'form-password-input input-group' },
+        React.createElement(_.FormInput, _extends({}, other, {
           className: classes,
           'data-test-id': 'password-input',
+          isInvalid: isInvalid,
+          isValid: isValid,
           name: name,
           id: id,
           onBlur: onBlur,
           onChange: onChange,
           placeholder: placeholder,
+          size: size,
           type: hidePassword ? 'password' : 'text',
           value: value
-        }),
+        })),
         React.createElement(
           'div',
           { className: 'input-group-append' },
           React.createElement(
-            _Button2.default,
+            _.Button,
             {
               'data-test-id': 'password-input-button',
               icon: hidePassword ? 'preview' : 'previewHide',
               isOutline: true,
               onClick: this.togglePassword,
+              size: size,
               theme: 'gray-600'
             },
             React.createElement(
@@ -121,10 +126,13 @@ var FormPasswordInput = (_temp2 = _class = function (_React$Component) {
 }(React.Component), _class.propTypes = {
   className: _propTypes2.default.string,
   id: _propTypes2.default.string,
+  isInvalid: _propTypes2.default.bool,
+  isValid: _propTypes2.default.bool,
   name: _propTypes2.default.string,
   onBlur: _propTypes2.default.func.isRequired,
   onChange: _propTypes2.default.func.isRequired,
   placeholder: _propTypes2.default.string,
+  size: _propTypes2.default.oneOf(['sm', 'md', 'lg']),
   value: _propTypes2.default.string.isRequired
 }, _temp2);
 FormPasswordInput.defaultProps = {

--- a/dist/js/components/FormPasswordInput/FormPasswordInput.js
+++ b/dist/js/components/FormPasswordInput/FormPasswordInput.js
@@ -78,13 +78,13 @@ var FormPasswordInput = (_temp2 = _class = function (_React$Component) {
 
       var hidePassword = this.state.hidePassword;
 
-      var classes = (0, _classnames2.default)(className, 'form-password-input', 'input-group');
+      var classes = (0, _classnames2.default)(className, 'form-control');
 
       return React.createElement(
         'div',
-        _extends({}, other, { className: classes }),
+        _extends({}, other, { className: 'form-password-input input-group' }),
         React.createElement('input', {
-          className: 'form-control',
+          className: classes,
           'data-test-id': 'password-input',
           name: name,
           id: id,

--- a/src/js/components/FormPasswordInput/FormPasswordInput.js
+++ b/src/js/components/FormPasswordInput/FormPasswordInput.js
@@ -1,15 +1,18 @@
 // @flow
 import * as React from 'react';
 import classNames from 'classnames';
-import Button from '../Button/Button';
+import { FormInput, Button } from '../../';
 
 type Props = {
   className?: string,
   id?: string,
+  isInvalid?: boolean,
+  isValid?: boolean,
   name?: string,
   onBlur: (SyntheticKeyboardEvent<HTMLInputElement>) => void,
   onChange: (SyntheticKeyboardEvent<HTMLInputElement>) => void,
   placeholder?: string,
+  size?: 'sm' | 'md' | 'lg',
   value: string,
 };
 
@@ -33,20 +36,36 @@ class FormPasswordInput extends React.Component<Props, State> {
   };
 
   render() {
-    const { className, onChange, onBlur, value, id, name, placeholder, ...other } = this.props;
+    const {
+      className,
+      onChange,
+      onBlur,
+      value,
+      id,
+      isInvalid,
+      isValid,
+      name,
+      placeholder,
+      size,
+      ...other
+    } = this.props;
     const { hidePassword } = this.state;
     const classes = classNames(className, 'form-control');
 
     return (
-      <div {...other} className="form-password-input input-group">
-        <input
+      <div className="form-password-input input-group">
+        <FormInput
+          {...other}
           className={classes}
           data-test-id="password-input"
+          isInvalid={isInvalid}
+          isValid={isValid}
           name={name}
           id={id}
           onBlur={onBlur}
           onChange={onChange}
           placeholder={placeholder}
+          size={size}
           type={hidePassword ? 'password' : 'text'}
           value={value}
         />
@@ -56,6 +75,7 @@ class FormPasswordInput extends React.Component<Props, State> {
             icon={hidePassword ? 'preview' : 'previewHide'}
             isOutline
             onClick={this.togglePassword}
+            size={size}
             theme="gray-600"
           >
             <span className="form-password-input__toggle-password-text">

--- a/src/js/components/FormPasswordInput/FormPasswordInput.js
+++ b/src/js/components/FormPasswordInput/FormPasswordInput.js
@@ -35,12 +35,12 @@ class FormPasswordInput extends React.Component<Props, State> {
   render() {
     const { className, onChange, onBlur, value, id, name, placeholder, ...other } = this.props;
     const { hidePassword } = this.state;
-    const classes = classNames(className, 'form-password-input', 'input-group');
+    const classes = classNames(className, 'form-control');
 
     return (
-      <div {...other} className={classes}>
+      <div {...other} className="form-password-input input-group">
         <input
-          className="form-control"
+          className={classes}
           data-test-id="password-input"
           name={name}
           id={id}

--- a/src/js/components/FormPasswordInput/FormPasswordInput.spec.js
+++ b/src/js/components/FormPasswordInput/FormPasswordInput.spec.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import merge from 'lodash/merge';
 import FormPasswordInput from './FormPasswordInput';
 import Button from '../Button/Button';
+import FormInput from '../FormInput/FormInput';
 
 const setup = (overrides = {}) => {
   const props = merge(
@@ -15,7 +16,7 @@ const setup = (overrides = {}) => {
   );
   const wrapper = shallow(<FormPasswordInput {...props} />);
 
-  return { wrapper, props, button: wrapper.find(Button), input: wrapper.find('input') };
+  return { wrapper, props, button: wrapper.find(Button), input: wrapper.find(FormInput) };
 };
 
 describe('<FormPasswordInput />', () => {
@@ -30,15 +31,17 @@ describe('<FormPasswordInput />', () => {
 
     wrapper.setProps({ className: 'custom' });
 
-    expect(wrapper.find('input').hasClass('form-control')).toBe(true);
-    expect(wrapper.find('input').hasClass('custom')).toBe(true);
+    const input = wrapper.find(FormInput);
+
+    expect(input.hasClass('form-control')).toBe(true);
+    expect(input.hasClass('custom')).toBe(true);
   });
 
   it('should pass through other props', () => {
-    const { wrapper } = setup({ tabIndex: 1, 'data-test': 'test', className: 'custom' });
+    const { input } = setup({ tabIndex: 1, 'data-test': 'test', className: 'custom' });
 
-    expect(wrapper.prop('tabIndex')).toEqual(1);
-    expect(wrapper.prop('data-test')).toEqual('test');
+    expect(input.prop('tabIndex')).toEqual(1);
+    expect(input.prop('data-test')).toEqual('test');
   });
 
   it('defaults name parameter to password', () => {
@@ -127,7 +130,7 @@ describe('<FormPasswordInput />', () => {
 
       wrapper.setState({ hidePassword: false });
 
-      const input = wrapper.find('input');
+      const input = wrapper.find(FormInput);
 
       expect(input.prop('type')).toEqual('text');
     });

--- a/src/js/components/FormPasswordInput/FormPasswordInput.spec.js
+++ b/src/js/components/FormPasswordInput/FormPasswordInput.spec.js
@@ -30,8 +30,8 @@ describe('<FormPasswordInput />', () => {
 
     wrapper.setProps({ className: 'custom' });
 
-    expect(wrapper.hasClass('form-password-input')).toBe(true);
-    expect(wrapper.hasClass('custom')).toBe(true);
+    expect(wrapper.find('input').hasClass('form-control')).toBe(true);
+    expect(wrapper.find('input').hasClass('custom')).toBe(true);
   });
 
   it('should pass through other props', () => {

--- a/src/js/components/FormPasswordInput/__snapshots__/FormPasswordInput.spec.js.snap
+++ b/src/js/components/FormPasswordInput/__snapshots__/FormPasswordInput.spec.js.snap
@@ -4,7 +4,7 @@ exports[`<FormPasswordInput /> should render 1`] = `
 <div
   className="form-password-input input-group"
 >
-  <input
+  <FormInput
     className="form-control"
     data-test-id="password-input"
     name="password"


### PR DESCRIPTION
Make FormPasswordInput behave as an input by passing all props directly to it.  The surrounding div will not be exposed to props.