### PR TITLE
Add instagram as theme for icons

### DIFF
--- a/src/js/components/Icon/Icon.tsx
+++ b/src/js/components/Icon/Icon.tsx
@@ -55,7 +55,8 @@ const Icon: React.FC<Props> = ({
   );
 
   if (theme) {
-    delete style.fill;
+    if (theme === 'instagram') style.fill = 'url(#instagram-gradient)';
+    else delete style.fill;
   } else {
     style.fill = hover && hoverColor ? hoverColor : color;
   }
@@ -71,6 +72,15 @@ const Icon: React.FC<Props> = ({
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
+      <defs>
+        <radialGradient id="instagram-gradient" r="150%" cx="30%" cy="107%">
+          <stop stopColor="#fdf497" offset="0" />
+          <stop stopColor="#fdf497" offset="0.05" />
+          <stop stopColor="#fd5949" offset="0.45" />
+          <stop stopColor="#d6249f" offset="0.6" />
+          <stop stopColor="#285AEB" offset="0.9" />
+        </radialGradient>
+      </defs>
       {title && <title>{title}</title>}
       {icons[name]}
     </svg>

--- a/src/js/stories/utils/themes.ts
+++ b/src/js/stories/utils/themes.ts
@@ -19,4 +19,5 @@ export default {
   Facebook: 'facebook',
   Twitter: 'twitter',
   LinkedIn: 'linkedin',
+  Instagram: 'instagram',
 } as const;


### PR DESCRIPTION
I added the Instagram theme for the icon only. Since it's a gradient it's a bit tricky for SVGs, we can't do it as usual.

![image](https://user-images.githubusercontent.com/29859169/114380041-7cb11a80-9b81-11eb-98e4-54f30ddbd03f.png)
