### PR TITLE
Character counter show error over limit

### DIFF
--- a/src/js/components/CharacterCounter/CharacterCounter.tsx
+++ b/src/js/components/CharacterCounter/CharacterCounter.tsx
@@ -19,7 +19,7 @@ const CharacterCounter: React.FC<Props> = ({
 }: Props) => {
   const current = count || text.length;
   const classes = classNames(className, 'character-counter', {
-    'text-danger': max && current >= max,
+    'text-danger': max && current > max,
   });
 
   return (


### PR DESCRIPTION
## Proposed changes

Currently the character counter turns red when the character count is greater than or equal to the limit. We only want to show it when the character counter is greater than the limit.