### PR TITLE
Move i18next to peerdependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@dicebear/avatars": "^4.1.1",
     "@dicebear/avatars-initials-sprites": "^4.1.1",
     "classnames": "^2.2.6",
-    "i18next": "^21.9.2",
     "nanoid": "^3.1.22",
     "react-i18next": "^11.18.6",
     "react-lines-ellipsis": "^0.14.1",
@@ -55,8 +54,10 @@
   "peerDependencies": {
     "bootstrap": "^5.1.3",
     "date-fns": ">= 2.21.2",
+    "i18next": "^21.9.2",
     "react": ">= 16.8.3",
-    "react-dom": ">= 16.8.3"
+    "react-dom": ">= 16.8.3",
+    "react-i18next": "^11.18.6"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
@@ -95,6 +96,7 @@
     "glob": "^7.1.3",
     "handlebars": "^4.0.12",
     "husky": "^1.2.0",
+    "i18next": "^21.9.2",
     "jest": "^25.1.0",
     "json-loader": "^0.5.7",
     "lint-staged": "^8.1.0",
@@ -105,6 +107,7 @@
     "prettier": "^1.15.3",
     "react": "^16.8.3",
     "react-dom": "^16.8.3",
+    "react-i18next": "^11.18.6",
     "sass-loader": "^7.1.0",
     "storybook": "^6.0.21",
     "stylelint": "^13.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1045,10 +1045,17 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.14.5", "@babel/runtime@^7.17.2":
+"@babel/runtime@^7.14.5":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
   integrity sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
+"@babel/runtime@^7.17.2":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.22.5.tgz#8564dd588182ce0047d55d7a75e93921107b57ec"
+  integrity sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==
   dependencies:
     regenerator-runtime "^0.13.11"
 


### PR DESCRIPTION
Since we have the package on Platform I thought we'd add it as peer dependency to avoid version mismatch