### PR TITLE
PLATFORM-3404 - Allow Alert display type to be overwritten

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lightful/ray",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "Lightful style guide and component library",
   "main": "dist/js/index.js",
   "type": "dist/js/index.d.ts",

--- a/src/js/components/Alert/Alert.tsx
+++ b/src/js/components/Alert/Alert.tsx
@@ -12,6 +12,7 @@ type Props = {
   hideIcon?: boolean;
   children: React.ReactNode;
   containerFlexType?: string;
+  containerDisplayType?: string;
   [key: string]: any;
 };
 
@@ -24,6 +25,7 @@ const Alert: React.FC<Props> = ({
   tag: Tag = 'div',
   theme = 'primary',
   hideIcon = false,
+  containerDisplayType = 'd-flex',
   ...other
 }: Props) => {
   const classes = classNames(className, 'alert ', `alert-${theme}`);
@@ -37,7 +39,7 @@ const Alert: React.FC<Props> = ({
   return (
     <Tag {...other} className={classes}>
       {header && <h3 className="alert-heading mb-1">{header}</h3>}
-      <div className={`d-flex text-sm w-100 ${containerFlexType}`}>
+      <div className={`${containerDisplayType} text-sm w-100 ${containerFlexType}`}>
         {!hideIcon && (iconsByTheme[theme] || icon) && (
           <Icon
             className="me-1 flex-shrink-0"


### PR DESCRIPTION
## Proposed changes

The Alert container has the class d-flex hardcoded, this PR allows it to be overwritten while keeping the d-flex as the default to allow backwards compatibility.

## Types of changes

What types of changes does your code introduce to the project?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

Please use the following checklist before contributing to this repository.

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have implemented error checking and considered data not being available or loading
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have implemented correct type checking
- [ ] I have tested my changes on a mobile layout
- [ ] I have double checked with the team that I haven't introduced duplicates in functionalities (components, services, database changes, etc...)
- [ ] If required, designers have signed off my changes
- [ ] I have communicated the changes to the QA team and planned testing
- [ ] I have implemented e2e tests for the new functionality
